### PR TITLE
OP-18616: APIs to create/update/get/delete auth providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 out/
 /.idea/
 *.rdb
+*.jar
 
 .classpath
 .project

--- a/docker_build/gate.yml
+++ b/docker_build/gate.yml
@@ -126,6 +126,13 @@ management:
       show-components: always
 
 keycloak:
+  realm: myrealm
+  ldapName: ldap
+  samlName: saml
+  clientId: admin-rest-client
+  serverUrl: http://localhost:8080/admin
+  username: myuser
+  password: password
   auth:
     providers:
       - name: ldap

--- a/docker_build/gate.yml
+++ b/docker_build/gate.yml
@@ -295,12 +295,12 @@ keycloak:
             defaultValue: http://localhost:8080/realms/isd-poc-realm/saml/endpoint
             loadValues: NA
 
-          - name: importFromFile
-            display: Import from file
-            inputType: file
+          - name: singleSignOnServiceUrl
+            display: Single Sign-On Service URL
+            inputType: url
             required: false
-            helpText: Import from file
-            readonly: false
+            helpText: Single Sign-On Service URL
+            readonly: true
             placeholder: NA
             defaultValue: NA
             loadValues: NA

--- a/docker_build/gate.yml
+++ b/docker_build/gate.yml
@@ -295,36 +295,6 @@ keycloak:
             defaultValue: http://localhost:8080/realms/isd-poc-realm/saml/endpoint
             loadValues: NA
 
-          - name: serviceProviderEntityId
-            display: Service Provider Entity ID
-            inputType: url
-            required: true
-            helpText: Service Provider Entity ID
-            readonly: false
-            placeholder: NA
-            defaultValue: http://localhost:8080/realms/isd-poc-realm
-            loadValues: NA
-
-          - name: singleSignOnServiceUrl
-            display: Single Sign-On Service URL
-            inputType: url
-            required: true
-            helpText: Single Sign-On Service URL
-            readonly: false
-            placeholder: NA
-            defaultValue: NA
-            loadValues: NA
-
-          - name: importFromURL
-            display: Import from URL
-            inputType: url
-            required: false
-            helpText: Import from URL
-            readonly: false
-            placeholder: NA
-            defaultValue: NA
-            loadValues: NA
-
           - name: importFromFile
             display: Import from file
             inputType: file

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -47,7 +47,8 @@ dependencies {
   implementation "com.graphql-java-kickstart:graphql-spring-boot-starter:7.0.1"
   implementation "com.graphql-java-kickstart:graphql-java-tools:6.0.2"
 
-  implementation "io.springfox:springfox-swagger2"
+  implementation "io.springfox:springfox-swagger2:2.9.2"
+  implementation "io.springfox:springfox-swagger-ui:2.10.0"
 
   implementation 'org.springframework.boot:spring-boot-starter-cache'
   implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.9.2'

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -54,6 +54,7 @@ dependencies {
 
 
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.4.RELEASE'
+  implementation group: 'org.keycloak', name: 'keycloak-admin-client', version: '20.0.2'
 
 
   runtimeOnly "io.spinnaker.kork:kork-runtime"

--- a/gate-web/src/main/java/com/netflix/spinnaker/gate/config/SwaggerConfig.java
+++ b/gate-web/src/main/java/com/netflix/spinnaker/gate/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.netflix.spinnaker.gate.config;
+
+import java.util.Collections;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+  @Bean
+  public Docket productApi() {
+    return new Docket(DocumentationType.SWAGGER_2)
+        .select()
+        .apis(RequestHandlerSelectors.basePackage("com.opsmx"))
+        .build()
+        .apiInfo(metaData());
+  }
+
+  private ApiInfo metaData() {
+    ApiInfo apiInfo =
+        new ApiInfo(
+            "Gate Service APIs",
+            "Rest APIs for Gate Service",
+            "1.0",
+            null,
+            null,
+            null,
+            null,
+            Collections.emptyList());
+    return apiInfo;
+  }
+}

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/controller/AuthConfigurerController.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/controller/AuthConfigurerController.java
@@ -88,8 +88,7 @@ public class AuthConfigurerController {
       @PathVariable(name = "authProvider") String authProvider) {
     log.trace("getAuthProvider started");
     AuthProviderModel provider = keycloakAuthService.get(authProvider);
-    ResponseEntity<AuthProviderModel> response =
-        new ResponseEntity<>(provider, HttpStatus.ACCEPTED);
+    ResponseEntity<AuthProviderModel> response = new ResponseEntity<>(provider, HttpStatus.OK);
     log.trace("getAuthProvider ended");
     return response;
   }
@@ -103,13 +102,13 @@ public class AuthConfigurerController {
     return ResponseEntity.ok().build();
   }
 
-  @GetMapping(
+  @PutMapping(
       value = "/authProvider/{authProvider}/disable",
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<AuthProviderModel> disableAuthProvider(
       @PathVariable(name = "authProvider") String authProvider) {
     log.trace("disableAuthProvider started");
-    AuthProviderModel provider = keycloakAuthService.disble(authProvider);
+    AuthProviderModel provider = keycloakAuthService.disable(authProvider);
     ResponseEntity<AuthProviderModel> response =
         new ResponseEntity<>(provider, HttpStatus.ACCEPTED);
     log.trace("disableAuthProvider ended");

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/controller/AuthConfigurerController.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/controller/AuthConfigurerController.java
@@ -16,6 +16,7 @@
 
 package com.opsmx.spinnaker.gate.controller;
 
+import com.google.gson.Gson;
 import com.opsmx.spinnaker.gate.model.AuthProviderModel;
 import com.opsmx.spinnaker.gate.model.KeycloakAuthProvider;
 import com.opsmx.spinnaker.gate.model.KeycloakAuthProviderModel;
@@ -27,6 +28,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -37,6 +39,8 @@ public class AuthConfigurerController {
   @Autowired private KeycloakAuthProvider keycloakAuthProvider;
   @Autowired private KeycloakAutowireService keycloakAuthService;
 
+  private Gson gson = new Gson();
+
   @GetMapping(value = "/supported/providers", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<KeycloakAuthProviderModel> getSupportedAuthProviders() {
 
@@ -45,25 +49,35 @@ public class AuthConfigurerController {
     return ResponseEntity.ok(new KeycloakAuthProviderModel(keycloakAuthProvider.getProviders()));
   }
 
-  @PostMapping(
-      value = "/authProvider/{authProvider}/create",
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @RequestMapping(value = "/authProvider/{authProvider}/create", method = RequestMethod.POST)
   public ResponseEntity<AuthProviderModel> createAuthProvider(
-      @RequestBody AuthProviderModel authProviderModel,
+      @RequestPart(value = "file", required = false) MultipartFile file,
+      @RequestPart(value = "authProviderModel") String authProviderStr,
       @PathVariable(name = "authProvider") String authProvider) {
+    log.trace("createAuthProvider started");
+    AuthProviderModel authProviderModel = gson.fromJson(authProviderStr, AuthProviderModel.class);
+    if (file != null) {
+      authProviderModel.setFile(file);
+    }
     AuthProviderModel created = keycloakAuthService.create(authProvider, authProviderModel);
     ResponseEntity<AuthProviderModel> response = new ResponseEntity<>(created, HttpStatus.CREATED);
+    log.trace("createAuthProvider ended");
     return response;
   }
 
-  @PutMapping(
-      value = "/authProvider/{authProvider}/update",
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @RequestMapping(value = "/authProvider/{authProvider}/update", method = RequestMethod.PUT)
   public ResponseEntity<AuthProviderModel> updateAuthProvider(
-      @RequestBody AuthProviderModel authProviderModel,
+      @RequestPart(value = "file", required = false) MultipartFile file,
+      @RequestPart(value = "authProviderModel") String authProviderStr,
       @PathVariable(name = "authProvider") String authProvider) {
+    log.trace("updateAuthProvider started");
+    AuthProviderModel authProviderModel = gson.fromJson(authProviderStr, AuthProviderModel.class);
+    if (file != null) {
+      authProviderModel.setFile(file);
+    }
     AuthProviderModel updated = keycloakAuthService.update(authProvider, authProviderModel);
     ResponseEntity<AuthProviderModel> response = new ResponseEntity<>(updated, HttpStatus.ACCEPTED);
+    log.trace("updateAuthProvider ended");
     return response;
   }
 
@@ -72,27 +86,33 @@ public class AuthConfigurerController {
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<AuthProviderModel> getAuthProvider(
       @PathVariable(name = "authProvider") String authProvider) {
+    log.trace("getAuthProvider started");
     AuthProviderModel provider = keycloakAuthService.get(authProvider);
     ResponseEntity<AuthProviderModel> response =
         new ResponseEntity<>(provider, HttpStatus.ACCEPTED);
+    log.trace("getAuthProvider ended");
     return response;
   }
 
   @DeleteMapping(value = "/authProvider/{authProvider}/delete")
   public ResponseEntity deleteAuthProvider(
       @PathVariable(name = "authProvider") String authProvider) {
+    log.trace("deleteAuthProvider started");
     keycloakAuthService.delete(authProvider);
+    log.trace("deleteAuthProvider ended");
     return ResponseEntity.ok().build();
   }
 
   @GetMapping(
       value = "/authProvider/{authProvider}/disable",
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<AuthProviderModel> disbleAuthProvider(
+  public ResponseEntity<AuthProviderModel> disableAuthProvider(
       @PathVariable(name = "authProvider") String authProvider) {
+    log.trace("disableAuthProvider started");
     AuthProviderModel provider = keycloakAuthService.disble(authProvider);
     ResponseEntity<AuthProviderModel> response =
         new ResponseEntity<>(provider, HttpStatus.ACCEPTED);
+    log.trace("disableAuthProvider ended");
     return response;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/controller/AuthConfigurerController.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/controller/AuthConfigurerController.java
@@ -16,16 +16,17 @@
 
 package com.opsmx.spinnaker.gate.controller;
 
+import com.opsmx.spinnaker.gate.model.AuthProviderModel;
 import com.opsmx.spinnaker.gate.model.KeycloakAuthProvider;
 import com.opsmx.spinnaker.gate.model.KeycloakAuthProviderModel;
+import com.opsmx.spinnaker.gate.service.KeycloakAutowireService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthConfigurerController {
 
   @Autowired private KeycloakAuthProvider keycloakAuthProvider;
+  @Autowired private KeycloakAutowireService keycloakAuthService;
 
   @GetMapping(value = "/supported/providers", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<KeycloakAuthProviderModel> getSupportedAuthProviders() {
@@ -41,5 +43,56 @@ public class AuthConfigurerController {
     log.debug("Auth providers : {}", keycloakAuthProvider.getProviders());
 
     return ResponseEntity.ok(new KeycloakAuthProviderModel(keycloakAuthProvider.getProviders()));
+  }
+
+  @PostMapping(
+      value = "/authProvider/{authProvider}/create",
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<AuthProviderModel> createAuthProvider(
+      @RequestBody AuthProviderModel authProviderModel,
+      @PathVariable(name = "authProvider") String authProvider) {
+    AuthProviderModel created = keycloakAuthService.create(authProvider, authProviderModel);
+    ResponseEntity<AuthProviderModel> response = new ResponseEntity<>(created, HttpStatus.CREATED);
+    return response;
+  }
+
+  @PutMapping(
+      value = "/authProvider/{authProvider}/update",
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<AuthProviderModel> updateAuthProvider(
+      @RequestBody AuthProviderModel authProviderModel,
+      @PathVariable(name = "authProvider") String authProvider) {
+    AuthProviderModel updated = keycloakAuthService.update(authProvider, authProviderModel);
+    ResponseEntity<AuthProviderModel> response = new ResponseEntity<>(updated, HttpStatus.ACCEPTED);
+    return response;
+  }
+
+  @GetMapping(
+      value = "/authProvider/{authProvider}/get",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<AuthProviderModel> getAuthProvider(
+      @PathVariable(name = "authProvider") String authProvider) {
+    AuthProviderModel provider = keycloakAuthService.get(authProvider);
+    ResponseEntity<AuthProviderModel> response =
+        new ResponseEntity<>(provider, HttpStatus.ACCEPTED);
+    return response;
+  }
+
+  @DeleteMapping(value = "/authProvider/{authProvider}/delete")
+  public ResponseEntity deleteAuthProvider(
+      @PathVariable(name = "authProvider") String authProvider) {
+    keycloakAuthService.delete(authProvider);
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping(
+      value = "/authProvider/{authProvider}/disable",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<AuthProviderModel> disbleAuthProvider(
+      @PathVariable(name = "authProvider") String authProvider) {
+    AuthProviderModel provider = keycloakAuthService.disble(authProvider);
+    ResponseEntity<AuthProviderModel> response =
+        new ResponseEntity<>(provider, HttpStatus.ACCEPTED);
+    return response;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/model/AuthProviderModel.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/model/AuthProviderModel.java
@@ -16,6 +16,7 @@
 
 package com.opsmx.spinnaker.gate.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Map;
 import lombok.Data;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,5 +25,5 @@ import org.springframework.web.multipart.MultipartFile;
 public class AuthProviderModel {
   private String name;
   private Map<String, String> config;
-  private MultipartFile file;
+  @JsonIgnore private MultipartFile file;
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/model/AuthProviderModel.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/model/AuthProviderModel.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.opsmx.spinnaker.gate.model;
+
+import java.util.Map;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+public class AuthProviderModel {
+  private String name;
+  private Map<String, String> config;
+  private MultipartFile file;
+}

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/KeycloakAuthService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/KeycloakAuthService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.opsmx.spinnaker.gate.service;
+
+import com.opsmx.spinnaker.gate.model.AuthProviderModel;
+
+public interface KeycloakAuthService {
+  AuthProviderModel create(AuthProviderModel authProviderModel);
+
+  AuthProviderModel update(AuthProviderModel authProviderModel);
+
+  String getAuthType();
+
+  AuthProviderModel get();
+
+  void delete();
+
+  AuthProviderModel disable();
+}

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/KeycloakAutowireService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/KeycloakAutowireService.java
@@ -24,6 +24,9 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+/***
+ * An adapter service that invokes appropriate KeycloakAuthService based on AuthType
+ */
 @Service
 public class KeycloakAutowireService {
   private final Map<String, KeycloakAuthService> servicesByAuthType;

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/KeycloakAutowireService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/KeycloakAutowireService.java
@@ -54,7 +54,7 @@ public class KeycloakAutowireService {
     return servicesByAuthType.get(authProvider).create(authProviderModel);
   }
 
-  public AuthProviderModel disble(String authProvider) {
+  public AuthProviderModel disable(String authProvider) {
     return servicesByAuthType.get(authProvider).disable();
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/KeycloakAutowireService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/KeycloakAutowireService.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.opsmx.spinnaker.gate.service;
+
+import com.opsmx.spinnaker.gate.model.AuthProviderModel;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KeycloakAutowireService {
+  private final Map<String, KeycloakAuthService> servicesByAuthType;
+
+  @Autowired
+  public KeycloakAutowireService(List<KeycloakAuthService> services) {
+    servicesByAuthType =
+        services.stream()
+            .collect(Collectors.toMap(KeycloakAuthService::getAuthType, Function.identity()));
+  }
+
+  public void delete(String authProvider) {
+    servicesByAuthType.get(authProvider).delete();
+  }
+
+  public AuthProviderModel get(String authProvider) {
+    return servicesByAuthType.get(authProvider).get();
+  }
+
+  public AuthProviderModel update(String authProvider, AuthProviderModel authProviderModel) {
+    return servicesByAuthType.get(authProvider).update(authProviderModel);
+  }
+
+  public AuthProviderModel create(String authProvider, AuthProviderModel authProviderModel) {
+    return servicesByAuthType.get(authProvider).create(authProviderModel);
+  }
+
+  public AuthProviderModel disble(String authProvider) {
+    return servicesByAuthType.get(authProvider).disable();
+  }
+}

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/LdapKeycloakAuthService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/LdapKeycloakAuthService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.opsmx.spinnaker.gate.service;
+
+import com.opsmx.spinnaker.gate.model.AuthProviderModel;
+import com.opsmx.spinnaker.gate.util.KeycloakAuthUtils;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LdapKeycloakAuthService implements KeycloakAuthService {
+
+  @Value("${keycloak.ldapName:ldap}")
+  private String ldapName;
+
+  @Autowired private KeycloakAuthUtils keycloakAuthUtils;
+  /**
+   * @param authProviderModel
+   * @return
+   */
+  @Override
+  public AuthProviderModel create(AuthProviderModel authProviderModel) {
+    MultivaluedHashMap<String, String> config =
+        hashMapToMultivaluedHashMap(authProviderModel.getConfig());
+    keycloakAuthUtils.addLdapComponent(config);
+    return authProviderModel;
+  }
+
+  private MultivaluedHashMap<String, String> hashMapToMultivaluedHashMap(
+      Map<String, String> config) {
+    MultivaluedHashMap<String, String> map = new MultivaluedHashMap<>();
+    Optional.ofNullable(config).orElse(new HashMap<>()).entrySet().stream()
+        .forEach(entry -> map.add(entry.getKey(), entry.getValue()));
+    return map;
+  }
+
+  /**
+   * @param authProviderModel
+   * @return
+   */
+  @Override
+  public AuthProviderModel update(AuthProviderModel authProviderModel) {
+    MultivaluedHashMap<String, String> config =
+        hashMapToMultivaluedHashMap(authProviderModel.getConfig());
+    keycloakAuthUtils.updateLdapComponent(config);
+    return authProviderModel;
+  }
+
+  /** @return */
+  @Override
+  public String getAuthType() {
+    return ldapName;
+  }
+
+  /** @return */
+  @Override
+  public AuthProviderModel get() {
+    ComponentRepresentation ldap = keycloakAuthUtils.getLdapComponent();
+    Map<String, String> config = multivaluedHashMapToHashMap(ldap.getConfig());
+    AuthProviderModel model = new AuthProviderModel();
+    model.setName(ldap.getName());
+    model.setConfig(config);
+    return model;
+  }
+
+  private Map<String, String> multivaluedHashMapToHashMap(
+      MultivaluedHashMap<String, String> config) {
+    Map<String, String> map = new HashMap<>();
+    Optional.ofNullable(config).orElse(new MultivaluedHashMap<>()).entrySet().stream()
+        .forEach(
+            entry -> {
+              String value =
+                  Optional.ofNullable(entry.getValue()).orElse(new ArrayList<>()).stream()
+                      .findFirst()
+                      .orElse("");
+              map.put(entry.getKey(), value);
+            });
+    return map;
+  }
+
+  /** */
+  @Override
+  public void delete() {
+    keycloakAuthUtils.deleteLdapComponent();
+  }
+
+  /** @return */
+  @Override
+  public AuthProviderModel disable() {
+    return null;
+  }
+}

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/LdapKeycloakAuthService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/LdapKeycloakAuthService.java
@@ -35,6 +35,7 @@ public class LdapKeycloakAuthService implements KeycloakAuthService {
   private String ldapName;
 
   @Autowired private KeycloakAuthUtils keycloakAuthUtils;
+
   /**
    * @param authProviderModel
    * @return
@@ -67,13 +68,11 @@ public class LdapKeycloakAuthService implements KeycloakAuthService {
     return authProviderModel;
   }
 
-  /** @return */
   @Override
   public String getAuthType() {
     return ldapName;
   }
 
-  /** @return */
   @Override
   public AuthProviderModel get() {
     ComponentRepresentation ldap = keycloakAuthUtils.getLdapComponent();
@@ -99,13 +98,11 @@ public class LdapKeycloakAuthService implements KeycloakAuthService {
     return map;
   }
 
-  /** */
   @Override
   public void delete() {
     keycloakAuthUtils.deleteLdapComponent();
   }
 
-  /** @return */
   @Override
   public AuthProviderModel disable() {
     return null;

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/LdapKeycloakAuthService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/LdapKeycloakAuthService.java
@@ -76,6 +76,9 @@ public class LdapKeycloakAuthService implements KeycloakAuthService {
   @Override
   public AuthProviderModel get() {
     ComponentRepresentation ldap = keycloakAuthUtils.getLdapComponent();
+    if (ldap == null) {
+      return keycloakAuthUtils.getDefaultModel(ldapName);
+    }
     Map<String, String> config = multivaluedHashMapToHashMap(ldap.getConfig());
     AuthProviderModel model = new AuthProviderModel();
     model.setName(ldap.getName());

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/SamlKeycloakAuthService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/SamlKeycloakAuthService.java
@@ -85,6 +85,10 @@ public class SamlKeycloakAuthService implements KeycloakAuthService {
     boolean isEnabled = samlIdentityProvider.isEnabled();
     Map<String, String> config = new HashMap<>();
     config.put("enabled", Boolean.toString(isEnabled));
+    Map<String, String> samlConfig = samlIdentityProvider.getConfig();
+    if (samlConfig.containsKey("singleSignOnServiceUrl")) {
+      config.put("singleSignOnServiceUrl", samlConfig.get("singleSignOnServiceUrl"));
+    }
     AuthProviderModel model = new AuthProviderModel();
     model.setName(samlIdentityProvider.getAlias());
     model.setConfig(config);

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/SamlKeycloakAuthService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/SamlKeycloakAuthService.java
@@ -59,6 +59,7 @@ public class SamlKeycloakAuthService implements KeycloakAuthService {
   @Override
   public AuthProviderModel update(AuthProviderModel authProviderModel) {
     if (authProviderModel.getFile() != null) {
+      // Delete the old saml and update the new config as it is not overriding the old one.
       keycloakAuthUtils.deleteSamlIdentityProvider();
       keycloakAuthUtils.addSamlIdentityProvider(authProviderModel.getFile());
     }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/SamlKeycloakAuthService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/SamlKeycloakAuthService.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.opsmx.spinnaker.gate.service;
+
+import com.opsmx.spinnaker.gate.model.AuthProviderModel;
+import com.opsmx.spinnaker.gate.util.KeycloakAuthUtils;
+import java.util.HashMap;
+import java.util.Map;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SamlKeycloakAuthService implements KeycloakAuthService {
+
+  @Value("${keycloak.samlName:saml}")
+  private String samlName;
+
+  @Autowired private KeycloakAuthUtils keycloakAuthUtils;
+  /**
+   * @param authProviderModel
+   * @return
+   */
+  @Override
+  public AuthProviderModel create(AuthProviderModel authProviderModel) {
+    keycloakAuthUtils.addSamlIdentityProvider(authProviderModel.getFile());
+    String enabled = authProviderModel.getConfig().get("enabled");
+    if (!Boolean.getBoolean(enabled)) {
+      keycloakAuthUtils.disableSamlIdentityProvider();
+    }
+    return authProviderModel;
+  }
+
+  /**
+   * @param authProviderModel
+   * @return
+   */
+  @Override
+  public AuthProviderModel update(AuthProviderModel authProviderModel) {
+    if (authProviderModel.getFile() != null) {
+      keycloakAuthUtils.addSamlIdentityProvider(authProviderModel.getFile());
+    }
+    String enabled = authProviderModel.getConfig().get("enabled");
+    if (!Boolean.getBoolean(enabled)) {
+      keycloakAuthUtils.disableSamlIdentityProvider();
+    }
+    return authProviderModel;
+  }
+
+  /** @return */
+  @Override
+  public String getAuthType() {
+    return samlName;
+  }
+
+  /** @return */
+  @Override
+  public AuthProviderModel get() {
+    IdentityProviderRepresentation samlIdentityProvider =
+        keycloakAuthUtils.getSamlIdentityProvider();
+    boolean isEnabled = samlIdentityProvider.isEnabled();
+    Map<String, String> config = new HashMap<>();
+    config.put("enabled", Boolean.toString(isEnabled));
+    AuthProviderModel model = new AuthProviderModel();
+    model.setName(samlIdentityProvider.getAlias());
+    model.setConfig(config);
+    return model;
+  }
+
+  /** */
+  @Override
+  public void delete() {
+    keycloakAuthUtils.deleteSamlIdentityProvider();
+  }
+
+  /** @return */
+  @Override
+  public AuthProviderModel disable() {
+    return null;
+  }
+}

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/SamlKeycloakAuthService.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/service/SamlKeycloakAuthService.java
@@ -79,6 +79,9 @@ public class SamlKeycloakAuthService implements KeycloakAuthService {
   public AuthProviderModel get() {
     IdentityProviderRepresentation samlIdentityProvider =
         keycloakAuthUtils.getSamlIdentityProvider();
+    if (samlIdentityProvider == null) {
+      return keycloakAuthUtils.getDefaultModel(samlName);
+    }
     boolean isEnabled = samlIdentityProvider.isEnabled();
     Map<String, String> config = new HashMap<>();
     config.put("enabled", Boolean.toString(isEnabled));

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/util/KeycloakAuthUtils.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/util/KeycloakAuthUtils.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2023 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.opsmx.spinnaker.gate.util;
+
+import java.util.*;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.jetbrains.annotations.NotNull;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class KeycloakAuthUtils {
+
+  private Keycloak keycloak;
+
+  @Value("${keycloak.realmName:opsmxRealm}")
+  private String realmName;
+
+  @Value("${keycloak.ldapName:ldap}")
+  private String ldapName;
+
+  @Value("${keycloak.samlName:saml}")
+  private String samlName;
+
+  @Value("${keycloak.clientId:opsmx-client}")
+  private String clientId;
+
+  @Value("${keycloak.serverUrl}")
+  private String serverUrl;
+
+  @Value("${keycloak.username:}")
+  private String username;
+
+  @Value("${keycloak.password:}")
+  private String password;
+
+  @Value("${keycloak.token:}")
+  private String token;
+
+  public static final String USER_STORAGE_PROVIDER_TYPE =
+      "org.keycloak.storage.UserStorageProvider";
+  public static final String LDAP_STORAGE_MAPPER_TYPE =
+      "org.keycloak.storage.ldap.mappers.LDAPStorageMapper";
+
+  @PostConstruct
+  public void initKeycloak() {
+    KeycloakBuilder builder =
+        KeycloakBuilder.builder().serverUrl(serverUrl).realm(realmName).clientId(clientId);
+    if (token != null && !token.isEmpty()) {
+      builder = builder.grantType(OAuth2Constants.CLIENT_CREDENTIALS).clientSecret(token);
+    } else {
+      builder = builder.grantType("password").username(username).password(password);
+    }
+
+    keycloak = builder.build();
+  }
+
+  @PreDestroy
+  public void closeKeycloak() {
+    keycloak.close();
+  }
+
+  public RealmResource getRealm() {
+    return keycloak.realm(realmName);
+  }
+
+  public void addLdapComponent(MultivaluedHashMap<String, String> config) {
+    RealmResource realmResource = getRealm();
+    RealmRepresentation realm = realmResource.toRepresentation();
+    String id = realm.getId();
+    ComponentRepresentation componentRepresentation = populateComponentRepresentation(config, id);
+    realmResource.components().add(componentRepresentation);
+  }
+
+  @NotNull
+  private ComponentRepresentation populateComponentRepresentation(
+      MultivaluedHashMap<String, String> config, String id) {
+    ComponentRepresentation componentRepresentation = new ComponentRepresentation();
+    componentRepresentation.setName(ldapName);
+    componentRepresentation.setConfig(config);
+    componentRepresentation.setParentId(id);
+    componentRepresentation.setProviderType(USER_STORAGE_PROVIDER_TYPE);
+    return componentRepresentation;
+  }
+
+  public void updateLdapComponent(MultivaluedHashMap<String, String> config) {
+    ComponentRepresentation componentRepresentation = getLdapComponent();
+    componentRepresentation.setConfig(config);
+    RealmResource realmResource = getRealm();
+    realmResource.components().add(componentRepresentation);
+  }
+
+  public void deleteLdapComponent() {
+    ComponentRepresentation componentRepresentation = getLdapComponent();
+    RealmResource realmResource = getRealm();
+    realmResource.components().component(componentRepresentation.getId()).remove();
+  }
+
+  public ComponentRepresentation disableLdapComponent() {
+    ComponentRepresentation componentRepresentation = getLdapComponent();
+    componentRepresentation.getConfig().put("enabled", Arrays.asList("false"));
+    RealmResource realmResource = getRealm();
+    realmResource
+        .components()
+        .component(componentRepresentation.getId())
+        .update(componentRepresentation);
+    return componentRepresentation;
+  }
+
+  public ComponentRepresentation getLdapComponent() {
+    RealmResource realmResource = getRealm();
+    RealmRepresentation realm = realmResource.toRepresentation();
+    String id = realm.getId();
+    List<ComponentRepresentation> componentsResource =
+        realmResource.components().query(id, USER_STORAGE_PROVIDER_TYPE);
+    return Optional.ofNullable(componentsResource).orElse(new ArrayList<>()).stream()
+        .filter(cr -> cr.getName().equalsIgnoreCase(ldapName))
+        .findFirst()
+        .map(ComponentRepresentation::getId)
+        .map(componentId -> realmResource.components().query(componentId, LDAP_STORAGE_MAPPER_TYPE))
+        .orElse(new ArrayList<>())
+        .stream()
+        .findFirst()
+        .orElse(null);
+  }
+
+  public void addSamlIdentityProvider(MultipartFile data) {
+    Map<String, String> config = getRealm().identityProviders().importFrom(data);
+
+    getRealm().identityProviders().create(populateIdentityProviderRepresentation(config));
+  }
+
+  public IdentityProviderRepresentation disableSamlIdentityProvider() {
+    IdentityProviderRepresentation idpRep = getSamlIdentityProvider();
+    idpRep.setEnabled(false);
+    getRealm().identityProviders().get(samlName).update(idpRep);
+    return idpRep;
+  }
+
+  private IdentityProviderRepresentation populateIdentityProviderRepresentation(
+      Map<String, String> config) {
+    IdentityProviderRepresentation identityProviderRepresentation =
+        new IdentityProviderRepresentation();
+    identityProviderRepresentation.setAlias(samlName);
+    identityProviderRepresentation.setConfig(config);
+    return identityProviderRepresentation;
+  }
+
+  public IdentityProviderRepresentation getSamlIdentityProvider() {
+    RealmResource realmResource = getRealm();
+    return realmResource.identityProviders().get(samlName).toRepresentation();
+  }
+
+  public void deleteSamlIdentityProvider() {
+    getRealm().identityProviders().get(samlName).remove();
+  }
+}

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/util/KeycloakAuthUtils.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/util/KeycloakAuthUtils.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.ws.rs.core.MediaType;
+import lombok.extern.slf4j.Slf4j;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
@@ -39,6 +40,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 @Component
+@Slf4j
 public class KeycloakAuthUtils {
 
   private Keycloak keycloak;
@@ -98,6 +100,7 @@ public class KeycloakAuthUtils {
     ComponentRepresentation componentRepresentation =
         populateComponentRepresentation(config, realm.getId());
     realmResource.components().add(componentRepresentation);
+    log.info("Successfully added ldap: {} ", componentRepresentation);
   }
 
   private ComponentRepresentation populateComponentRepresentation(
@@ -119,12 +122,14 @@ public class KeycloakAuthUtils {
         .components()
         .component(componentRepresentation.getId())
         .update(componentRepresentation);
+    log.info("Successfully updated ldap: {} ", componentRepresentation);
   }
 
   public void deleteLdapComponent() {
     ComponentRepresentation componentRepresentation = getLdapComponent();
     RealmResource realmResource = getRealm();
     realmResource.components().component(componentRepresentation.getId()).remove();
+    log.info("Successfully deleted ldap: {} ", componentRepresentation);
   }
 
   public ComponentRepresentation getLdapComponent() {
@@ -141,7 +146,10 @@ public class KeycloakAuthUtils {
 
   public void addSamlIdentityProvider(MultipartFile data) {
     Map<String, String> config = getConfig(data);
-    getRealm().identityProviders().create(populateIdentityProviderRepresentation(config));
+    IdentityProviderRepresentation identityProvider =
+        populateIdentityProviderRepresentation(config);
+    getRealm().identityProviders().create(identityProvider);
+    log.info("Successfully added saml: {} ", identityProvider);
   }
 
   private Map<String, String> getConfig(MultipartFile data) {
@@ -178,6 +186,7 @@ public class KeycloakAuthUtils {
     IdentityProviderRepresentation idpRep = getSamlIdentityProvider();
     idpRep.setEnabled(false);
     getRealm().identityProviders().get(samlName).update(idpRep);
+    log.info("Successfully disabled saml: {} ", idpRep);
     return idpRep;
   }
 
@@ -199,5 +208,6 @@ public class KeycloakAuthUtils {
 
   public void deleteSamlIdentityProvider() {
     getRealm().identityProviders().get(samlName).remove();
+    log.info("Successfully deleted saml.");
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/util/KeycloakAuthUtils.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/util/KeycloakAuthUtils.java
@@ -16,12 +16,10 @@
 
 package com.opsmx.spinnaker.gate.util;
 
+import com.opsmx.spinnaker.gate.model.AuthProviderModel;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.ws.rs.core.MediaType;
@@ -30,6 +28,7 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.resource.IdentityProviderResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.representations.idm.ComponentRepresentation;
@@ -203,11 +202,23 @@ public class KeycloakAuthUtils {
 
   public IdentityProviderRepresentation getSamlIdentityProvider() {
     RealmResource realmResource = getRealm();
-    return realmResource.identityProviders().get(samlName).toRepresentation();
+    IdentityProviderResource identityProviderResource =
+        realmResource.identityProviders().get(samlName);
+
+    return identityProviderResource == null ? null : identityProviderResource.toRepresentation();
   }
 
   public void deleteSamlIdentityProvider() {
     getRealm().identityProviders().get(samlName).remove();
     log.info("Successfully deleted saml.");
+  }
+
+  public AuthProviderModel getDefaultModel(String name) {
+    AuthProviderModel model = new AuthProviderModel();
+    model.setName(name);
+    Map<String, String> config = new HashMap<>();
+    config.put("enabled", "false");
+    model.setConfig(config);
+    return model;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/util/KeycloakAuthUtils.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/util/KeycloakAuthUtils.java
@@ -28,7 +28,6 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
-import org.keycloak.admin.client.resource.IdentityProviderResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.representations.idm.ComponentRepresentation;
@@ -202,10 +201,11 @@ public class KeycloakAuthUtils {
 
   public IdentityProviderRepresentation getSamlIdentityProvider() {
     RealmResource realmResource = getRealm();
-    IdentityProviderResource identityProviderResource =
-        realmResource.identityProviders().get(samlName);
-
-    return identityProviderResource == null ? null : identityProviderResource.toRepresentation();
+    List<IdentityProviderRepresentation> idps = realmResource.identityProviders().findAll();
+    if (idps == null || idps.isEmpty()) {
+      return null;
+    }
+    return realmResource.identityProviders().get(samlName).toRepresentation();
   }
 
   public void deleteSamlIdentityProvider() {


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-18469
https://devopsmx.atlassian.net/browse/OP-18616
https://devopsmx.atlassian.net/browse/OP-18369

UTC:
Added new ldap auth config
Modified ldap auth config
Disabled ldap auth
Deleted ldap auth
Above cases with saml too
Retrieved ldap and saml configs 

Unit test cases will be addressed as part of https://devopsmx.atlassian.net/browse/OP-19033