### PR TITLE
OP-19389, OP-19545 : Added session fixation strategy as none in custom token filter authentication

### DIFF
--- a/gate-core/src/main/java/com/opsmx/spinnaker/gate/CustomTokenSecurityConfig.java
+++ b/gate-core/src/main/java/com/opsmx/spinnaker/gate/CustomTokenSecurityConfig.java
@@ -33,6 +33,8 @@ public class CustomTokenSecurityConfig extends WebSecurityConfigurerAdapter {
     authConfig.configure(httpSecurity);
     httpSecurity
         .sessionManagement()
+        .sessionFixation()
+        .none()
         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         .and()
         .requestCache()


### PR DESCRIPTION
This is added so that spring does not invalidate existing valid session.

https://devopsmx.atlassian.net/browse/OP-19545 
https://devopsmx.atlassian.net/browse/OP-19389