### PR TITLE
Op 21719 gate

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
@@ -36,13 +36,9 @@ class OpsmxAuthController {
   @RequestMapping(value = "/redirectauto", method = RequestMethod.GET)
   void redirectAuto(HttpServletRequest request, HttpServletResponse response, @RequestParam String to) {
     log.info("to url : {}", to)
-    String host = request.getHeader("authority")
-    Enumeration headerNames = request.getHeaderNames()
-    while (headerNames.hasMoreElements()) {
-      System.out.println("Header  " + headerNames.nextElement())
-      log.info("Header Value is :{}",request.getHeader(headerNames.nextElement()))
-    }
-    validAutoRedirect(to,host) ?
+    String hostUrl = request.getRequestURI()
+    log.info("reqeust url : {}", hostUrl)
+    validAutoRedirect(to,hostUrl) ?
       response.sendRedirect(to) :
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Requested redirect address not recognized.")
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
@@ -36,7 +36,7 @@ class OpsmxAuthController {
   @RequestMapping(value = "/redirectauto", method = RequestMethod.GET)
   void redirectAuto(HttpServletRequest request, HttpServletResponse response, @RequestParam String to) {
     log.info("to url : {}", to)
-    String host = request.getRemoteHost()
+    String host = request.getHeader("authority")
     validAutoRedirect(to,host) ?
       response.sendRedirect(to) :
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Requested redirect address not recognized.")
@@ -49,6 +49,11 @@ class OpsmxAuthController {
       log.info("HOST:{}",host)
       String domain = toURL.getHost()
       log.info("DOMAIN:{}",domain)
+      if (!domain.equals(host)) {
+        log.info("DOMAINS ARE DIFFERENT ")
+      } else {
+        log.info("DOMAINS ARE SAME")
+      }
 
     } catch (MalformedURLException malEx) {
       log.warn "Malformed redirect URL: $to\n${ExceptionUtils.getStackTrace(malEx)}"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
@@ -36,7 +36,7 @@ class OpsmxAuthController {
   @RequestMapping(value = "/redirectauto", method = RequestMethod.GET)
   void redirectAuto(HttpServletRequest request, HttpServletResponse response, @RequestParam String to) {
     log.info("to url : {}", to)
-    log.info("refer: {}",request.getHeader("Referer"))
+    log.info("refer: {}",request.getHeader("referer"))
     validAutoRedirect(to,request.getRequestURL().toString()) ?
       response.sendRedirect(to) :
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Requested redirect address not recognized.")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
@@ -36,7 +36,7 @@ class OpsmxAuthController {
   @RequestMapping(value = "/redirectauto", method = RequestMethod.GET)
   void redirectAuto(HttpServletRequest request, HttpServletResponse response, @RequestParam String to) {
     log.info("to url : {}", to)
-    String hostUrl = request.getRequestURI()
+    String hostUrl = request.getRequestURL().toString()
     log.info("reqeust url : {}", hostUrl)
     validAutoRedirect(to,hostUrl) ?
       response.sendRedirect(to) :

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
@@ -37,6 +37,11 @@ class OpsmxAuthController {
   void redirectAuto(HttpServletRequest request, HttpServletResponse response, @RequestParam String to) {
     log.info("to url : {}", to)
     String host = request.getHeader("authority")
+    Enumeration headerNames = request.getHeaderNames()
+    while (headerNames.hasMoreElements()) {
+      System.out.println("Header  " + headerNames.nextElement())
+      log.info("Header Value is :{}",request.getHeader(headerNames.nextElement()))
+    }
     validAutoRedirect(to,host) ?
       response.sendRedirect(to) :
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Requested redirect address not recognized.")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
@@ -36,7 +36,6 @@ class OpsmxAuthController {
   @RequestMapping(value = "/redirectauto", method = RequestMethod.GET)
   void redirectAuto(HttpServletRequest request, HttpServletResponse response, @RequestParam String to) {
     log.info("to url : {}", to)
-    log.info("refer: {}",request.getHeader("referer"))
     validAutoRedirect(to,request.getRequestURL().toString()) ?
       response.sendRedirect(to) :
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Requested redirect address not recognized.")
@@ -48,16 +47,9 @@ class OpsmxAuthController {
     try {
       toURL = new URL(to)
       hostURL = new URL(from)
-      log.info("from URL :{}",hostURL)
-      log.info("to DOMAIN:{}",toURL.getHost())
-      log.info("from DOMAIN:{}",hostURL.getHost())
       if (!toURL.getHost().equals(hostURL.getHost())) {
-        log.info("DOMAINS ARE DIFFERENT ")
         return false
-      } else {
-        log.info("DOMAINS ARE SAME")
       }
-
     } catch (MalformedURLException malEx) {
       log.warn "Malformed redirect URL: $to\n${ExceptionUtils.getStackTrace(malEx)}"
       return false

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
@@ -36,21 +36,23 @@ class OpsmxAuthController {
   @RequestMapping(value = "/redirectauto", method = RequestMethod.GET)
   void redirectAuto(HttpServletRequest request, HttpServletResponse response, @RequestParam String to) {
     log.info("to url : {}", to)
-    String hostUrl = request.getRequestURL().toString()
-    log.info("reqeust url : {}", hostUrl)
-    validAutoRedirect(to,hostUrl) ?
+    log.info("reqeust url : {}", request.getRequestURL().toString())
+    validAutoRedirect(to,request.getRequestURL().toString()) ?
       response.sendRedirect(to) :
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Requested redirect address not recognized.")
   }
 
-  boolean validAutoRedirect(String to,String host) {
+  boolean validAutoRedirect(String to,String from) {
     URL toURL
+    URL hostURL
     try {
       toURL = new URL(to)
-      log.info("HOST:{}",host)
-      String domain = toURL.getHost()
-      log.info("DOMAIN:{}",domain)
-      if (!domain.equals(host)) {
+      hostURL = new URL(from)
+      log.info("from URL :{}",hostURL)
+      log.info("to DOMAIN:{}",toURL.getHost())
+      log.info("from DOMAIN:{}",hostURL.getHost())
+
+      if (!toURL.getHost().equals(hostURL.getHost())) {
         log.info("DOMAINS ARE DIFFERENT ")
       } else {
         log.info("DOMAINS ARE SAME")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
@@ -36,7 +36,7 @@ class OpsmxAuthController {
   @RequestMapping(value = "/redirectauto", method = RequestMethod.GET)
   void redirectAuto(HttpServletRequest request, HttpServletResponse response, @RequestParam String to) {
     log.info("to url : {}", to)
-    log.info("reqeust url : {}", request.getRequestURL().toString())
+    log.info("refer: {}",request.getHeader("Referer"))
     validAutoRedirect(to,request.getRequestURL().toString()) ?
       response.sendRedirect(to) :
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Requested redirect address not recognized.")
@@ -51,9 +51,9 @@ class OpsmxAuthController {
       log.info("from URL :{}",hostURL)
       log.info("to DOMAIN:{}",toURL.getHost())
       log.info("from DOMAIN:{}",hostURL.getHost())
-
       if (!toURL.getHost().equals(hostURL.getHost())) {
         log.info("DOMAINS ARE DIFFERENT ")
+        return false
       } else {
         log.info("DOMAINS ARE SAME")
       }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OpsmxAuthController.groovy
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 import javax.servlet.http.HttpServletResponse
+import javax.servlet.http.HttpServletRequest
 
 @Slf4j
 @RestController
@@ -33,17 +34,22 @@ class OpsmxAuthController {
 
   @ApiOperation(value = "Redirect to Deck")
   @RequestMapping(value = "/redirectauto", method = RequestMethod.GET)
-  void redirectAuto(HttpServletResponse response, @RequestParam String to) {
+  void redirectAuto(HttpServletRequest request, HttpServletResponse response, @RequestParam String to) {
     log.info("to url : {}", to)
-    validAutoRedirect(to) ?
+    String host = request.getRemoteHost()
+    validAutoRedirect(to,host) ?
       response.sendRedirect(to) :
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Requested redirect address not recognized.")
   }
 
-  boolean validAutoRedirect(String to) {
+  boolean validAutoRedirect(String to,String host) {
     URL toURL
     try {
       toURL = new URL(to)
+      log.info("HOST:{}",host)
+      String domain = toURL.getHost()
+      log.info("DOMAIN:{}",domain)
+
     } catch (MalformedURLException malEx) {
       log.warn "Malformed redirect URL: $to\n${ExceptionUtils.getStackTrace(malEx)}"
       return false


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-21719

Test Cases:
1)After log in  verified  redirected  url  is  with same domain (opsmx domain) in this case it will redirect to given url
2)After log in  verfied  redirected  url  is with  other domain domain  (like googgle.com) in this case it will throw error