### PR TITLE
OP-22435: Bugfix spin cli trigger a pipeline user is admin or not for custom gate.

### DIFF
--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApplicationIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApplicationIdRbacInterceptor.java
@@ -35,7 +35,7 @@ public class ApplicationIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.debug("***********Start of the preHandle -- ApplicationIdRbacInterceptor");
+    log.debug("Start of the preHandle -- ApplicationIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class ApplicationIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-    log.debug("***********End of the preHandle -- ApplicationIdRbacInterceptor");
+    log.debug("End of the preHandle -- ApplicationIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApplicationIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApplicationIdRbacInterceptor.java
@@ -35,6 +35,7 @@ public class ApplicationIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
+    log.debug("***********Start of the preHandle -- ApplicationIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -43,7 +44,7 @@ public class ApplicationIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-
+    log.debug("***********End of the preHandle -- ApplicationIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalGateIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalGateIdRbacInterceptor.java
@@ -35,7 +35,7 @@ public class ApprovalGateIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.debug("***********Start of the preHandle -- ApprovalGateIdRbacInterceptor");
+    log.debug("Start of the preHandle -- ApprovalGateIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class ApprovalGateIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-    log.debug("***********End of the preHandle -- ApprovalGateIdRbacInterceptor");
+    log.debug("End of the preHandle -- ApprovalGateIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalGateIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalGateIdRbacInterceptor.java
@@ -35,7 +35,7 @@ public class ApprovalGateIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-
+    log.debug("***********Start of the preHandle -- ApprovalGateIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class ApprovalGateIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-
+    log.debug("***********End of the preHandle -- ApprovalGateIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalGateInstanceIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalGateInstanceIdRbacInterceptor.java
@@ -35,7 +35,7 @@ public class ApprovalGateInstanceIdRbacInterceptor implements HandlerInterceptor
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.debug("***********Start of the preHandle -- ApprovalGateInstanceIdRbacInterceptor");
+    log.debug("Start of the preHandle -- ApprovalGateInstanceIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class ApprovalGateInstanceIdRbacInterceptor implements HandlerInterceptor
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-    log.debug("***********End of the preHandle -- ApprovalGateInstanceIdRbacInterceptor");
+    log.debug("End of the preHandle -- ApprovalGateInstanceIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalGateInstanceIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalGateInstanceIdRbacInterceptor.java
@@ -35,7 +35,7 @@ public class ApprovalGateInstanceIdRbacInterceptor implements HandlerInterceptor
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-
+    log.debug("***********Start of the preHandle -- ApprovalGateInstanceIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class ApprovalGateInstanceIdRbacInterceptor implements HandlerInterceptor
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-
+    log.debug("***********End of the preHandle -- ApprovalGateInstanceIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalPolicyIdInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalPolicyIdInterceptor.java
@@ -35,7 +35,7 @@ public class ApprovalPolicyIdInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.debug("***********Start of the preHandle -- ApprovalPolicyIdInterceptor");
+    log.debug("Start of the preHandle -- ApprovalPolicyIdInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class ApprovalPolicyIdInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-    log.debug("***********End of the preHandle -- ApprovalPolicyIdInterceptor");
+    log.debug("End of the preHandle -- ApprovalPolicyIdInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalPolicyIdInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ApprovalPolicyIdInterceptor.java
@@ -35,7 +35,7 @@ public class ApprovalPolicyIdInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-
+    log.debug("***********Start of the preHandle -- ApprovalPolicyIdInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class ApprovalPolicyIdInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-
+    log.debug("***********End of the preHandle -- ApprovalPolicyIdInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/CustomGatesTriggerRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/CustomGatesTriggerRbacInterceptor.java
@@ -37,7 +37,7 @@ public class CustomGatesTriggerRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-
+    log.debug("***********Start of the preHandle -- CustomGatesTriggerRbacInterceptor");
     Optional.ofNullable(request.getHeader("x-spinnaker-user"))
         .orElseThrow(
             () -> new XSpinnakerUserHeaderMissingException("x-spinnaker-user header missing"));
@@ -50,7 +50,7 @@ public class CustomGatesTriggerRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-
+    log.debug("***********End of the preHandle -- CustomGatesTriggerRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/CustomGatesTriggerRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/CustomGatesTriggerRbacInterceptor.java
@@ -37,7 +37,7 @@ public class CustomGatesTriggerRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.debug("***********Start of the preHandle -- CustomGatesTriggerRbacInterceptor");
+    log.debug("Start of the preHandle -- CustomGatesTriggerRbacInterceptor");
     Optional.ofNullable(request.getHeader("x-spinnaker-user"))
         .orElseThrow(
             () -> new XSpinnakerUserHeaderMissingException("x-spinnaker-user header missing"));
@@ -50,7 +50,7 @@ public class CustomGatesTriggerRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-    log.debug("***********End of the preHandle -- CustomGatesTriggerRbacInterceptor");
+    log.debug("End of the preHandle -- CustomGatesTriggerRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/FeatureVisibilityRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/FeatureVisibilityRbacInterceptor.java
@@ -46,12 +46,14 @@ public class FeatureVisibilityRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.info("request intercepted to authorize if the user is having feature visibility");
+    log.debug("***********Start of the preHandle -- FeatureVisibilityRbacInterceptor");
+    log.info("request intercepted to authorize if the user is having feature visibility ");
     String origin = request.getHeader(HttpHeaders.ORIGIN);
     if (origin != null && customGatePlugins.contains(origin)) {
       return true;
     }
     applicationFeatureRbac.authorizeUserForFeatureVisibility(request.getUserPrincipal().getName());
+    log.debug("***********End of the preHandle -- FeatureVisibilityRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/FeatureVisibilityRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/FeatureVisibilityRbacInterceptor.java
@@ -46,14 +46,14 @@ public class FeatureVisibilityRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.debug("***********Start of the preHandle -- FeatureVisibilityRbacInterceptor");
+    log.debug("Start of the preHandle -- FeatureVisibilityRbacInterceptor");
     log.info("request intercepted to authorize if the user is having feature visibility ");
     String origin = request.getHeader(HttpHeaders.ORIGIN);
     if (origin != null && customGatePlugins.contains(origin)) {
       return true;
     }
     applicationFeatureRbac.authorizeUserForFeatureVisibility(request.getUserPrincipal().getName());
-    log.debug("***********End of the preHandle -- FeatureVisibilityRbacInterceptor");
+    log.debug("End of the preHandle -- FeatureVisibilityRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/GateIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/GateIdRbacInterceptor.java
@@ -35,7 +35,7 @@ public class GateIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-
+    log.debug("***********Start of the preHandle -- GateIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class GateIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-
+    log.debug("***********End of the preHandle -- GateIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/GateIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/GateIdRbacInterceptor.java
@@ -35,7 +35,7 @@ public class GateIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.debug("***********Start of the preHandle -- GateIdRbacInterceptor");
+    log.debug("Start of the preHandle -- GateIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class GateIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-    log.debug("***********End of the preHandle -- GateIdRbacInterceptor");
+    log.debug("End of the preHandle -- GateIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/PipelineIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/PipelineIdRbacInterceptor.java
@@ -46,6 +46,7 @@ public class PipelineIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
+    log.debug("***********Start of the preHandle -- PipelineIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -59,7 +60,7 @@ public class PipelineIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-
+    log.debug("***********End of the preHandle -- PipelineIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/PipelineIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/PipelineIdRbacInterceptor.java
@@ -46,7 +46,7 @@ public class PipelineIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.debug("***********Start of the preHandle -- PipelineIdRbacInterceptor");
+    log.debug("Start of the preHandle -- PipelineIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -60,7 +60,7 @@ public class PipelineIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-    log.debug("***********End of the preHandle -- PipelineIdRbacInterceptor");
+    log.debug("End of the preHandle -- PipelineIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ServiceIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ServiceIdRbacInterceptor.java
@@ -35,6 +35,7 @@ public class ServiceIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
+    log.debug("***********Start of the preHandle -- ServiceIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -43,7 +44,7 @@ public class ServiceIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-
+    log.debug("***********End of the preHandle -- ServiceIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ServiceIdRbacInterceptor.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/interceptors/ServiceIdRbacInterceptor.java
@@ -35,7 +35,7 @@ public class ServiceIdRbacInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    log.debug("***********Start of the preHandle -- ServiceIdRbacInterceptor");
+    log.debug("Start of the preHandle -- ServiceIdRbacInterceptor");
     try {
       log.info(
           "Request intercepted for authorizing if the user is having enough access to perform the action");
@@ -44,7 +44,7 @@ public class ServiceIdRbacInterceptor implements HandlerInterceptor {
     } catch (NumberFormatException nfe) {
       log.debug("Ignoring the rbac check as it threw number format exception");
     }
-    log.debug("***********End of the preHandle -- ServiceIdRbacInterceptor");
+    log.debug("End of the preHandle -- ServiceIdRbacInterceptor");
     return true;
   }
 }

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/rbac/ApplicationFeatureRbac.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/rbac/ApplicationFeatureRbac.java
@@ -44,7 +44,7 @@ public class ApplicationFeatureRbac {
 
   @Autowired private OesAuthorizationService oesAuthorizationService;
 
-  @Autowired PermissionService permissionService;
+  @Autowired private PermissionService permissionService;
 
   public static final List<String> runtime_access = new ArrayList<>();
   public static final List<String> applicationFeatureRbacEndpoints = new ArrayList<>();

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/rbac/ApplicationFeatureRbac.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/rbac/ApplicationFeatureRbac.java
@@ -124,7 +124,6 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForApplicationId");
         break;
 
       case "PUT":
@@ -162,9 +161,9 @@ public class ApplicationFeatureRbac {
                     + TO_PERFORM_THIS_OPERATION);
           }
         }
-        log.debug("End of the authorizeUserForApplicationId");
         break;
     }
+    log.debug("End of the authorizeUserForApplicationId");
   }
 
   private Integer getApplicationId(String endpoint) {
@@ -231,7 +230,6 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForServiceId");
         break;
 
       case "PUT":
@@ -262,9 +260,9 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForServiceId");
         break;
     }
+    log.debug("End of the authorizeUserForServiceId");
   }
 
   private Integer getServiceId(String endpoint) {
@@ -325,7 +323,6 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForPipelineId");
         break;
 
       case "PUT":
@@ -358,9 +355,9 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForPipelineId");
         break;
     }
+    log.debug("End of the authorizeUserForPipelineId");
   }
 
   private Integer getPipelineId(String endpoint) {
@@ -421,7 +418,6 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForGateId");
         break;
 
       case "PUT":
@@ -451,9 +447,9 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForGateId");
         break;
     }
+    log.debug("End of the authorizeUserForGateId");
   }
 
   private Integer getGateId(String endpoint) {
@@ -522,7 +518,6 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForApprovalGateId");
         break;
 
       case "PUT":
@@ -555,9 +550,9 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForApprovalGateId");
         break;
     }
+    log.debug("End of the authorizeUserForApprovalGateId");
   }
 
   private Integer getApprovalGateId(String endpoint) {
@@ -619,7 +614,6 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForApprovalGateInstanceId");
         break;
 
       case "PUT":
@@ -652,9 +646,9 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForApprovalGateInstanceId");
         break;
     }
+    log.debug("End of the authorizeUserForApprovalGateInstanceId");
   }
 
   private Integer getApprovalGateInstanceId(String endpoint) {
@@ -716,7 +710,6 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForApprovalPolicyId");
         break;
 
       case "PUT":
@@ -749,9 +742,9 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
-        log.debug("End of the authorizeUserForApprovalPolicyId");
         break;
     }
+    log.debug("End of the authorizeUserForApprovalPolicyId");
   }
 
   private Integer getApprovalPolicyId(String endpoint) {

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/rbac/ApplicationFeatureRbac.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/rbac/ApplicationFeatureRbac.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.netflix.spinnaker.gate.model.PermissionModel;
 import com.netflix.spinnaker.gate.services.OesAuthorizationService;
+import com.netflix.spinnaker.gate.services.PermissionService;
 import com.opsmx.spinnaker.gate.enums.PermissionEnum;
 import com.opsmx.spinnaker.gate.enums.RbacFeatureType;
 import com.opsmx.spinnaker.gate.exception.AccessForbiddenException;
@@ -42,6 +43,9 @@ import org.springframework.stereotype.Component;
 public class ApplicationFeatureRbac {
 
   @Autowired private OesAuthorizationService oesAuthorizationService;
+
+  @Autowired
+  PermissionService permissionService;
 
   public static final List<String> runtime_access = new ArrayList<>();
   public static final List<String> applicationFeatureRbacEndpoints = new ArrayList<>();
@@ -71,13 +75,17 @@ public class ApplicationFeatureRbac {
   public void authorizeUserForFeatureVisibility(String userName) {
 
     Boolean isFeatureVisibility;
-
+    log.debug("validating the user for FeatureVisibility");
+    if (permissionService.isAdmin(userName)) {
+      log.info("{} is admin, Hence not validating with ISD", userName);
+      return;
+    }
     isFeatureVisibility =
-        Boolean.parseBoolean(
-            oesAuthorizationService
-                .isFeatureVisibility(userName, RbacFeatureType.APP.name(), userName)
-                .getBody()
-                .get("isEnabled"));
+      Boolean.parseBoolean(
+        oesAuthorizationService
+          .isFeatureVisibility(userName, RbacFeatureType.APP.name(), userName)
+          .getBody()
+          .get("isEnabled"));
     log.info("is feature visibility enabled : {}", isFeatureVisibility);
     if (!isFeatureVisibility) {
       throw new AccessForbiddenException(
@@ -86,8 +94,12 @@ public class ApplicationFeatureRbac {
   }
 
   public void authorizeUserForApplicationId(
-      String username, String endpointUrl, String httpMethod) {
-
+    String username, String endpointUrl, String httpMethod) {
+    log.debug("validating the user for ApplicationId");
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     HttpMethod method = HttpMethod.valueOf(httpMethod);
     Integer applicationId = getApplicationId(endpointUrl);
     PermissionModel permission;
@@ -176,6 +188,11 @@ public class ApplicationFeatureRbac {
 
   public void authorizeUserForServiceId(String username, String endpointUrl, String httpMethod) {
 
+    log.debug("validating the user for ServiceId");
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     HttpMethod method = HttpMethod.valueOf(httpMethod);
     Integer serviceId = getServiceId(endpointUrl);
     Boolean isAuthorized;
@@ -262,6 +279,11 @@ public class ApplicationFeatureRbac {
 
   public void authorizeUserForPipelineId(String username, String endpointUrl, String httpMethod) {
 
+    log.debug("validating the user for PipelineId");
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     HttpMethod method = HttpMethod.valueOf(httpMethod);
     Integer pipelineId = getPipelineId(endpointUrl);
     Boolean isAuthorized;
@@ -350,6 +372,11 @@ public class ApplicationFeatureRbac {
 
   public void authorizeUserForGateId(String username, String endpointUrl, String httpMethod) {
 
+    log.debug("validating the user for GateId");
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     HttpMethod method = HttpMethod.valueOf(httpMethod);
     Integer gateId = getGateId(endpointUrl);
     Boolean isAuthorized;
@@ -442,6 +469,11 @@ public class ApplicationFeatureRbac {
   public void authorizeUserForApprovalGateId(
       String username, String endpointUrl, String httpMethod) {
 
+    log.debug("validating the user for GateId");
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     HttpMethod method = HttpMethod.valueOf(httpMethod);
     Integer approvalGateId = getApprovalGateId(endpointUrl);
     Boolean isAuthorized;
@@ -529,6 +561,11 @@ public class ApplicationFeatureRbac {
   public void authorizeUserForApprovalGateInstanceId(
       String username, String endpointUrl, String httpMethod) {
 
+    log.debug("validating the user for ApprovalGateInstanceId");
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     HttpMethod method = HttpMethod.valueOf(httpMethod);
     Integer approvalGateInstanceId = getApprovalGateInstanceId(endpointUrl);
     Boolean isAuthorized;
@@ -618,6 +655,11 @@ public class ApplicationFeatureRbac {
   public void authorizeUserForApprovalPolicyId(
       String username, String endpointUrl, String httpMethod) {
 
+    log.debug("validating the user for ApprovalPolicyId");
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     HttpMethod method = HttpMethod.valueOf(httpMethod);
     Integer approvalPolicyId = getApprovalPolicyId(endpointUrl);
     Boolean isAuthorized;
@@ -720,7 +762,12 @@ public class ApplicationFeatureRbac {
 
   public void authorizeUserForApprovalGateTrigger(HttpServletRequest request) {
 
+    log.debug("validating the user for ApprovalGateTrigger");
     String username = readXSpinnakerUserFromHeader(request);
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     String endpointUrl = request.getRequestURI();
 
     Integer approvalGateId = getApprovalGateId(endpointUrl);
@@ -757,7 +804,13 @@ public class ApplicationFeatureRbac {
 
   public void authorizeUserForPolicyGateTrigger(HttpServletRequest request, Object input) {
 
+    log.debug("validating the user for ApprovalGateTrigger");
+
     String username = readXSpinnakerUserFromHeader(request);
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     String endpointUrl = request.getRequestURI();
 
     String inputStr = gson.toJson(input);
@@ -805,7 +858,12 @@ public class ApplicationFeatureRbac {
   public void authorizeUserForVerificationAndTestVerificationGateTrigger(
       HttpServletRequest request, Object input) {
 
+    log.debug("validating the user for ApprovalGateTrigger");
     String username = readXSpinnakerUserFromHeader(request);
+    if (permissionService.isAdmin(username)) {
+      log.info("{} is admin, Hence not validating with ISD", username);
+      return;
+    }
     String endpointUrl = request.getRequestURI();
 
     String inputStr = gson.toJson(input);

--- a/gate-web/src/main/java/com/opsmx/spinnaker/gate/rbac/ApplicationFeatureRbac.java
+++ b/gate-web/src/main/java/com/opsmx/spinnaker/gate/rbac/ApplicationFeatureRbac.java
@@ -44,8 +44,7 @@ public class ApplicationFeatureRbac {
 
   @Autowired private OesAuthorizationService oesAuthorizationService;
 
-  @Autowired
-  PermissionService permissionService;
+  @Autowired PermissionService permissionService;
 
   public static final List<String> runtime_access = new ArrayList<>();
   public static final List<String> applicationFeatureRbacEndpoints = new ArrayList<>();
@@ -75,26 +74,29 @@ public class ApplicationFeatureRbac {
   public void authorizeUserForFeatureVisibility(String userName) {
 
     Boolean isFeatureVisibility;
+    log.debug("Start of the authorizeUserForFeatureVisibility");
     log.debug("validating the user for FeatureVisibility");
     if (permissionService.isAdmin(userName)) {
       log.info("{} is admin, Hence not validating with ISD", userName);
       return;
     }
     isFeatureVisibility =
-      Boolean.parseBoolean(
-        oesAuthorizationService
-          .isFeatureVisibility(userName, RbacFeatureType.APP.name(), userName)
-          .getBody()
-          .get("isEnabled"));
+        Boolean.parseBoolean(
+            oesAuthorizationService
+                .isFeatureVisibility(userName, RbacFeatureType.APP.name(), userName)
+                .getBody()
+                .get("isEnabled"));
     log.info("is feature visibility enabled : {}", isFeatureVisibility);
     if (!isFeatureVisibility) {
       throw new AccessForbiddenException(
           "You do not have permission for the feature type : " + RbacFeatureType.APP.description);
     }
+    log.debug("End of the authorizeUserForFeatureVisibility");
   }
 
   public void authorizeUserForApplicationId(
-    String username, String endpointUrl, String httpMethod) {
+      String username, String endpointUrl, String httpMethod) {
+    log.debug("Start of the authorizeUserForApplicationId");
     log.debug("validating the user for ApplicationId");
     if (permissionService.isAdmin(username)) {
       log.info("{} is admin, Hence not validating with ISD", username);
@@ -122,6 +124,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForApplicationId");
         break;
 
       case "PUT":
@@ -159,6 +162,7 @@ public class ApplicationFeatureRbac {
                     + TO_PERFORM_THIS_OPERATION);
           }
         }
+        log.debug("End of the authorizeUserForApplicationId");
         break;
     }
   }
@@ -188,6 +192,7 @@ public class ApplicationFeatureRbac {
 
   public void authorizeUserForServiceId(String username, String endpointUrl, String httpMethod) {
 
+    log.debug("Start of the authorizeUserForServiceId");
     log.debug("validating the user for ServiceId");
     if (permissionService.isAdmin(username)) {
       log.info("{} is admin, Hence not validating with ISD", username);
@@ -226,6 +231,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForServiceId");
         break;
 
       case "PUT":
@@ -256,6 +262,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForServiceId");
         break;
     }
   }
@@ -279,6 +286,7 @@ public class ApplicationFeatureRbac {
 
   public void authorizeUserForPipelineId(String username, String endpointUrl, String httpMethod) {
 
+    log.debug("Start of the authorizeUserForPipelineId");
     log.debug("validating the user for PipelineId");
     if (permissionService.isAdmin(username)) {
       log.info("{} is admin, Hence not validating with ISD", username);
@@ -317,6 +325,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForPipelineId");
         break;
 
       case "PUT":
@@ -349,6 +358,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForPipelineId");
         break;
     }
   }
@@ -372,6 +382,7 @@ public class ApplicationFeatureRbac {
 
   public void authorizeUserForGateId(String username, String endpointUrl, String httpMethod) {
 
+    log.debug("Start of the authorizeUserForGateId");
     log.debug("validating the user for GateId");
     if (permissionService.isAdmin(username)) {
       log.info("{} is admin, Hence not validating with ISD", username);
@@ -410,6 +421,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForGateId");
         break;
 
       case "PUT":
@@ -439,6 +451,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForGateId");
         break;
     }
   }
@@ -469,6 +482,7 @@ public class ApplicationFeatureRbac {
   public void authorizeUserForApprovalGateId(
       String username, String endpointUrl, String httpMethod) {
 
+    log.debug("Start of the authorizeUserForApprovalGateId");
     log.debug("validating the user for GateId");
     if (permissionService.isAdmin(username)) {
       log.info("{} is admin, Hence not validating with ISD", username);
@@ -508,6 +522,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForApprovalGateId");
         break;
 
       case "PUT":
@@ -540,6 +555,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForApprovalGateId");
         break;
     }
   }
@@ -561,6 +577,7 @@ public class ApplicationFeatureRbac {
   public void authorizeUserForApprovalGateInstanceId(
       String username, String endpointUrl, String httpMethod) {
 
+    log.debug("Start of the authorizeUserForApprovalGateInstanceId");
     log.debug("validating the user for ApprovalGateInstanceId");
     if (permissionService.isAdmin(username)) {
       log.info("{} is admin, Hence not validating with ISD", username);
@@ -602,6 +619,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForApprovalGateInstanceId");
         break;
 
       case "PUT":
@@ -634,6 +652,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForApprovalGateInstanceId");
         break;
     }
   }
@@ -655,6 +674,7 @@ public class ApplicationFeatureRbac {
   public void authorizeUserForApprovalPolicyId(
       String username, String endpointUrl, String httpMethod) {
 
+    log.debug("Start of the authorizeUserForApprovalPolicyId");
     log.debug("validating the user for ApprovalPolicyId");
     if (permissionService.isAdmin(username)) {
       log.info("{} is admin, Hence not validating with ISD", username);
@@ -696,6 +716,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForApprovalPolicyId");
         break;
 
       case "PUT":
@@ -728,6 +749,7 @@ public class ApplicationFeatureRbac {
                   + RbacFeatureType.APP.description
                   + TO_PERFORM_THIS_OPERATION);
         }
+        log.debug("End of the authorizeUserForApprovalPolicyId");
         break;
     }
   }
@@ -762,6 +784,7 @@ public class ApplicationFeatureRbac {
 
   public void authorizeUserForApprovalGateTrigger(HttpServletRequest request) {
 
+    log.debug("Start of the authorizeUserForApprovalGateTrigger");
     log.debug("validating the user for ApprovalGateTrigger");
     String username = readXSpinnakerUserFromHeader(request);
     if (permissionService.isAdmin(username)) {
@@ -800,10 +823,12 @@ public class ApplicationFeatureRbac {
               + RbacFeatureType.APP.description
               + TO_PERFORM_THIS_OPERATION);
     }
+    log.debug("End of the authorizeUserForApprovalGateTrigger");
   }
 
   public void authorizeUserForPolicyGateTrigger(HttpServletRequest request, Object input) {
 
+    log.debug("Start of the authorizeUserForPolicyGateTrigger");
     log.debug("validating the user for ApprovalGateTrigger");
 
     String username = readXSpinnakerUserFromHeader(request);
@@ -853,11 +878,13 @@ public class ApplicationFeatureRbac {
               + RbacFeatureType.APP.description
               + TO_PERFORM_THIS_OPERATION);
     }
+    log.debug("End of the authorizeUserForPolicyGateTrigger");
   }
 
   public void authorizeUserForVerificationAndTestVerificationGateTrigger(
       HttpServletRequest request, Object input) {
 
+    log.debug("Start of the authorizeUserForVerificationAndTestVerificationGateTrigger");
     log.debug("validating the user for ApprovalGateTrigger");
     String username = readXSpinnakerUserFromHeader(request);
     if (permissionService.isAdmin(username)) {
@@ -903,6 +930,7 @@ public class ApplicationFeatureRbac {
               + RbacFeatureType.APP.description
               + TO_PERFORM_THIS_OPERATION);
     }
+    log.debug("End of the authorizeUserForVerificationAndTestVerificationGateTrigger");
   }
 
   private static void populateDashboardServiceApis() {


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-22435

**CodeChanges** - As ISD is not aware of the usergroups/roles of x509 users. But in fiat, they're recognized as admin users,
hence skipping the validation for x509-users in ISD.
Added logs in all interceptors prehandle methods for clear debugging.