### PR TITLE
OP-22790: Bugfix for return the exception messages implemented the  ExceptionHandler for OesRequestException and PipelineException

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -116,6 +116,8 @@ class PipelineController {
     String resultStatus = result.get("status")
 
     if (!"SUCCEEDED".equalsIgnoreCase(resultStatus)) {
+      log.debug("Pipeline save operation failed. Result: {}", result)
+
       String exception = result.variables.find { it.key == "exception" }?.value?.details?.errors?.getAt(0)
       throw new PipelineException(
         exception ?: "Pipeline save operation did not succeed: ${result.get("id", "unknown task id")} (status: ${resultStatus})"

--- a/gate-web/src/main/groovy/com/opsmx/spinnaker/gate/exception/RetrofitErrorHandler.groovy
+++ b/gate-web/src/main/groovy/com/opsmx/spinnaker/gate/exception/RetrofitErrorHandler.groovy
@@ -78,34 +78,32 @@ class RetrofitErrorHandler {
   @ExceptionHandler(PipelineController.PipelineException)
   @ResponseBody
   ResponseEntity<Map<String, Object>> handlePipelineException(PipelineController.PipelineException ex) {
-    Map<String, Object> response = [:]
-    response.put("error", "Pipeline Save Error")
-    response.put("message", ex.message)
-    response.put("status", HttpStatus.BAD_REQUEST.value())
-    response.put("timestamp", System.currentTimeMillis())
-    log.error("Pipeline Exception occurred: {}", ex.getMessage(), ex);
+    log.error("PipelineException occurred: {}", ex.message, ex)
+    Map<String, Object> response = createResponseMap(ex, "Pipeline Save Error")
 
     if (ex.additionalAttributes) {
       response.put("additionalAttributes", ex.additionalAttributes)
     }
-
-    log.error("PipelineException occurred: {}", ex.message, ex)
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST)
   }
-
 
   @ExceptionHandler(OesRequestException)
   @ResponseBody
   ResponseEntity<Map<String, Object>> handleOesRequestException(OesRequestException ex) {
+    log.error("OesRequestException occurred: {}", ex.message, ex)
+    Map<String, Object> response = createResponseMap(ex, "OES Request Exception")
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST)
+  }
+
+  private Map<String, Object> createResponseMap(Exception ex, String errorMessage) {
     Map<String, Object> response = [:]
-    response.put("error", "OES Request Exception")
+    response.put("error", errorMessage)
     response.put("message", ex.message)
     response.put("status", HttpStatus.BAD_REQUEST.value())
     response.put("timestamp", System.currentTimeMillis())
-    log.error("OesRequest Exception occurred: {}", ex.getMessage(), ex);
-    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-  }
 
+    return response
+  }
 
 
   private ErrorResponseModel populateDefaultErrorResponseModel() {

--- a/gate-web/src/main/groovy/com/opsmx/spinnaker/gate/exception/RetrofitErrorHandler.groovy
+++ b/gate-web/src/main/groovy/com/opsmx/spinnaker/gate/exception/RetrofitErrorHandler.groovy
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.gate.controllers.OpsmxDashboardController
 import com.netflix.spinnaker.gate.controllers.OpsmxOesController
 import com.netflix.spinnaker.gate.controllers.OpsmxPlatformController
 import com.netflix.spinnaker.gate.controllers.OpsmxVisibilityController
+import com.netflix.spinnaker.gate.controllers.PipelineController
+import com.netflix.spinnaker.gate.exceptions.OesRequestException
 import com.opsmx.spinnaker.gate.controllers.OpsmxAuditClientServiceController
 import com.opsmx.spinnaker.gate.controllers.OpsmxAuditServiceController
 import com.opsmx.spinnaker.gate.controllers.OpsmxSaporPolicyController
@@ -45,12 +47,14 @@ class RetrofitErrorHandler {
   @ExceptionHandler([RetrofitError.class])
   @ResponseBody ResponseEntity<Object> handleRetrofitError(RetrofitError retrofitError){
     if (retrofitError!=null){
-      log.warn("Exception occurred in OES downstream services : {}", retrofitError.getMessage())
+      log.warn("Exception occurred in OES downstream services : {}", retrofitError.getBody())
       if (retrofitError.getKind() == RetrofitError.Kind.NETWORK){
+        log.warn("Retrofit Exception occurred of kind Network : {}", retrofitError.getBody())
         ErrorResponseModel networkErrorResponse = populateNetworkErrorResponse(retrofitError)
         return new ResponseEntity<Object>(networkErrorResponse, HttpStatus.INTERNAL_SERVER_ERROR)
       }
       if (retrofitError.getResponse()!=null && retrofitError.getResponse().getStatus() > 0){
+        log.warn("Exception occurred in  : {}", retrofitError.getBody())
         if (retrofitError.getResponse().getBody() !=null){
           InputStream inputStream = null
           try {
@@ -70,6 +74,38 @@ class RetrofitErrorHandler {
     ErrorResponseModel defaultErrorResponse = populateDefaultErrorResponseModel()
     return new ResponseEntity<Object>(defaultErrorResponse, HttpStatus.INTERNAL_SERVER_ERROR)
   }
+
+  @ExceptionHandler(PipelineController.PipelineException)
+  @ResponseBody
+  ResponseEntity<Map<String, Object>> handlePipelineException(PipelineController.PipelineException ex) {
+    Map<String, Object> response = [:]
+    response.put("error", "Pipeline Save Error")
+    response.put("message", ex.message)
+    response.put("status", HttpStatus.BAD_REQUEST.value())
+    response.put("timestamp", System.currentTimeMillis())
+    log.error("Pipeline Exception occurred: {}", ex.getMessage(), ex);
+
+    if (ex.additionalAttributes) {
+      response.put("additionalAttributes", ex.additionalAttributes)
+    }
+
+    log.error("PipelineException occurred: {}", ex.message, ex)
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST)
+  }
+
+
+  @ExceptionHandler(OesRequestException)
+  @ResponseBody
+  ResponseEntity<Map<String, Object>> handleOesRequestException(OesRequestException ex) {
+    Map<String, Object> response = [:]
+    response.put("error", "OES Request Exception")
+    response.put("message", ex.message)
+    response.put("status", HttpStatus.BAD_REQUEST.value())
+    response.put("timestamp", System.currentTimeMillis())
+    log.error("OesRequest Exception occurred: {}", ex.getMessage(), ex);
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
 
 
   private ErrorResponseModel populateDefaultErrorResponseModel() {


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-22790
https://devopsmx.atlassian.net/browse/OP-22004

Changes:
PIpeline related error messages and OesRequestException in cloudTargets page are not getting passed to UI in proper format by GenericExceptionHandlers after upgrade.
Hence added ExcpetionHandler for PipelineException and OesRequestException.
Issue got resolved and Error message is properly visible.

![Screenshot from 2024-10-11 19-52-31](https://github.com/user-attachments/assets/a2250d21-10a6-42b1-9098-789d08455936)
![Screenshot from 2024-10-15 19-54-51](https://github.com/user-attachments/assets/f73de7f8-f6a3-420a-9ec7-36672d59e568)
